### PR TITLE
support list of json objects input to json2insert

### DIFF
--- a/cr8/cli.py
+++ b/cr8/cli.py
@@ -25,6 +25,13 @@ def dicts_from_stdin():
         {
             "name": "n1"
         }
+
+    Or a list of JSON objects:
+
+        [
+            {"name": "n1"},
+            {"name": "n2"},
+        ]
     """
     if sys.stdin.isatty():
         raise SystemExit('Expected json input via stdin')
@@ -32,4 +39,8 @@ def dicts_from_stdin():
         try:
             yield json.loads(line)
         except json.decoder.JSONDecodeError:
-            yield json.loads(line + '\n' + sys.stdin.read())
+            dicts = json.loads(line + '\n' + sys.stdin.read())
+            if isinstance(dicts, list):
+                yield from dicts
+            else:
+                yield dicts

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,19 @@ class CliTest(TestCase):
         self.assertEqual({"name": "n1"}, d1)
         self.assertRaises(StopIteration, next, dicts)
 
+    @patch('sys.stdin', new_callable=lambda: io.StringIO(
+        '[\n{\n"name": "n1"\n},\n{\n"name": "n2"\n}\n]'))
+    def test_dicts_from_json_list_of_obj(self, stdin):
+
+        dicts = iter(dicts_from_stdin())
+        d1 = next(dicts)
+        d2 = next(dicts)
+
+        self.assertEqual({"name": "n1"}, d1)
+        self.assertEqual({"name": "n2"}, d2)
+
+        self.assertRaises(StopIteration, next, dicts)
+
     @patch('sys.stdin', new_callable=io.StringIO)
     def test_lines_from_stdin_isatty_but_default(self, stdin):
         stdin.isatty = lambda: True


### PR DESCRIPTION
This makes it possible to use the output of crash (using ``json``
format) directly.