### PR TITLE
initialize connection in callback

### DIFF
--- a/cr8/bench.py
+++ b/cr8/bench.py
@@ -31,9 +31,8 @@ class Executor:
         self.loop = aio.asyncio.get_event_loop()
 
         if result_hosts:
-            conn = connect(result_hosts)
-
             def process_result(result):
+                conn = connect(result_hosts)
                 cursor = conn.cursor()
                 stmt, args = to_insert('benchmarks', result.__dict__)
                 cursor.execute(stmt, args)


### PR DESCRIPTION
this prevents from running into a connection timeout if a consumer host
is specified.