### PR TITLE
expose `bulk_size` to result-set

### DIFF
--- a/cr8/bench.py
+++ b/cr8/bench.py
@@ -94,7 +94,8 @@ class Executor:
             started=start,
             ended=end,
             stats=stats,
-            concurrency=concurrency
+            concurrency=concurrency,
+            bulk_size=bulk_size
         ))
 
     def run_queries(self, queries):

--- a/cr8/timeit.py
+++ b/cr8/timeit.py
@@ -22,7 +22,8 @@ class Result:
                  started,
                  ended,
                  stats,
-                 concurrency):
+                 concurrency,
+                 bulk_size=None):
         self.version_info = version_info
         self.statement = statement
         # need ts in ms in crate
@@ -30,6 +31,7 @@ class Result:
         self.ended = int(ended * 1000)
         self.runtime_stats = stats.get()
         self.concurrency = concurrency
+        self.bulk_size = bulk_size
 
     def __str__(self):
         return json.dumps(self.__dict__)

--- a/sql/benchmarks_table.sql
+++ b/sql/benchmarks_table.sql
@@ -7,6 +7,7 @@ create table if not exists benchmarks (
     started timestamp,
     ended timestamp,
     concurrency int,
+    bulk_size int,
     runtime_stats object (strict) as (
         avg double,
         min double,


### PR DESCRIPTION
if the benchmark does not use any bulk_size (e.g. timeit) this column is
printed as NULL