### PR TITLE
Don't pre-init values with zeroes

### DIFF
--- a/cr8/metrics.py
+++ b/cr8/metrics.py
@@ -35,12 +35,12 @@ class UniformReservoir:
     def __init__(self, size):
         self.size = size
         self.count = 0
-        self.values = [0] * size
+        self.values = []
 
     def add(self, value):
         count = self.count
         if count < self.size:
-            self.values[count] = value
+            self.values.append(value)
         else:
             k = random.randint(0, self.count)
             if k < self.size:
@@ -65,8 +65,8 @@ class Stats:
             max=values[-1] if values else 0,
             mean=statistics.mean(values),
             median=statistics.median(values),
-            variance=statistics.variance(values),
-            stdev=statistics.stdev(values),
+            variance=statistics.variance(values) if len(values) > 1 else 0,
+            stdev=statistics.stdev(values) if len(values) > 1 else 0,
             # replace . with _ so that the output can be inserted into crate
             # crate doesn't allow dots in column names
             percentile={str(i[0]).replace('.', '_'): i[1] for i in

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -4,7 +4,23 @@ from doctest import DocTestSuite
 from cr8 import metrics
 
 
+class UniformReservoirTest(TestCase):
+
+    def test_fewer_values_than_size(self):
+        r = metrics.UniformReservoir(10)
+        r.add(10)
+        r.add(20)
+        self.assertEqual([10, 20], r.values)
+
+
 class StatsTest(TestCase):
+
+    def test_stats_with_only_1_value(self):
+        hist = metrics.Stats(size=4)
+        hist.measure(23.2)
+        result = hist.get()
+        self.assertEqual(result['stdev'], 0)
+        self.assertEqual(result['variance'], 0)
 
     def test_stats(self):
         hist = metrics.Stats(size=4)


### PR DESCRIPTION
If for example the size was set to 40 but only 2 requests were made the
result was useless because there would be 38 values with 0.

Fixes https://github.com/mfussenegger/cr8/issues/40