### PR TITLE
Use env option to disable tqdm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 
 install:
     - pip install .
+    - pip install fake-factory==0.5.7
 script:
     - python -m unittest
 

--- a/cr8/aio.py
+++ b/cr8/aio.py
@@ -1,6 +1,6 @@
 
 import functools
-import sys
+import os
 import asyncio
 import aiohttp
 import json
@@ -16,7 +16,7 @@ tqdm = functools.partial(
     tqdm,
     unit=' requests',
     smoothing=0.1,
-    disable=not sys.stdin.isatty()
+    disable=os.environ.get('CR8_NO_TQDM') == 'True'
 )
 
 


### PR DESCRIPTION
If `stdin.isatty` is used it would also disable tqdm if something like
`cat x.json | cr8 insert-json` is used.