### PR TITLE
Don't output histogram but include samples

### DIFF
--- a/cr8/metrics.py
+++ b/cr8/metrics.py
@@ -95,7 +95,6 @@ class Stats:
         return dict(
             min=min_,
             max=max_,
-            hist=get_histogram(values, min_, max_, stdev),
             mean=statistics.mean(values),
             median=statistics.median(values),
             variance=statistics.variance(values),
@@ -104,5 +103,6 @@ class Stats:
             # crate doesn't allow dots in column names
             percentile={str(i[0]).replace('.', '_'): i[1] for i in
                         zip(self.plevels, percentiles)},
-            n=self.reservoir.count
+            n=self.reservoir.count,
+            samples=values
         )

--- a/sql/benchmarks_table.sql
+++ b/sql/benchmarks_table.sql
@@ -24,9 +24,6 @@ create table if not exists benchmarks (
         n integer,
         variance double,
         stdev double,
-        hist array(object (strict) as (
-            bin double,
-            num int
-        ))
+        samples array(double)
     )
 ) clustered into 8 shards with (number_of_replicas = '1-3', column_policy='strict');


### PR DESCRIPTION
More flexible and samples can be used to draw histograms with
matplotlib.

Might re-add the histogram back later as some kind ouf `--output`
option.