### PR TITLE
Include unordered samples

### DIFF
--- a/cr8/metrics.py
+++ b/cr8/metrics.py
@@ -104,5 +104,5 @@ class Stats:
             percentile={str(i[0]).replace('.', '_'): i[1] for i in
                         zip(self.plevels, percentiles)},
             n=self.reservoir.count,
-            samples=values
+            samples=self.reservoir.values
         )


### PR DESCRIPTION
Instead of including the ordered samples in the output this will include
the unordered samples.

This has the advantage that it will be visible if the speed increases
over time. (For example if the JIT kicks in)