### PR TITLE
added Crate build date to benchmark result table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,4 @@
+- Added Crate build date column to version_info in benchmark result table
 
 2016-07-04 0.6.0
 ================

--- a/cr8/clients.py
+++ b/cr8/clients.py
@@ -1,6 +1,7 @@
 import json
 import aiohttp
 import itertools
+from datetime import datetime
 from typing import List, Union, Iterable
 
 
@@ -65,7 +66,8 @@ class HttpClient:
             version = r['version']
             return {
                 'hash': version['build_hash'],
-                'number': version['number']
+                'number': version['number'],
+                'date': datetime.strptime(version['build_timestamp'][:10], '%Y-%m-%d').isoformat(),
             }
 
     def close(self):

--- a/cr8/run_spec.py
+++ b/cr8/run_spec.py
@@ -19,7 +19,8 @@ BENCHMARK_TABLE = '''
 create table if not exists benchmarks (
     version_info object (strict) as (
         number string,
-        hash string
+        hash string,
+        date timestamp
     ),
     statement string,
     started timestamp,


### PR DESCRIPTION
This may be useful when visualizing benchmark results on a timeline.