### PR TITLE
added meta column to results table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-- Added ``spec_name`` column to results table.
+- Added ``meta`` object column to results table.
   It's now possible to add a name to the spec so the benchmark results can easily
   be identified by this spec label.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,6 @@
+- Added ``spec_name`` column to results table.
+  It's now possible to add a name to the spec so the benchmark results can easily
+  be identified by this spec label.
 
 2016-07-04 0.6.0
 ================

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ cluster::
         "runtime_stats": {
             ...
         },
+        "spec_name": null,
         "started": ...
         "statement": "select name from sys.cluster\n",
         "version_info": {
@@ -176,6 +177,7 @@ Usage::
         "concurrency": 2,
         "ended": ...,
         "runtime_stats": {...
+        "spec_name": "sample.toml",
         "started": ...
         "statement": "select count(*) from countries",
         "version_info": {

--- a/README.rst
+++ b/README.rst
@@ -72,10 +72,10 @@ cluster::
         "bulk_size": null,
         "concurrency": 1,
         "ended": ...
+        "meta": null,
         "runtime_stats": {
             ...
         },
-        "spec_name": null,
         "started": ...
         "statement": "select name from sys.cluster\n",
         "version_info": {
@@ -176,8 +176,10 @@ Usage::
         "bulk_size": null,
         "concurrency": 2,
         "ended": ...,
+        "meta": {
+            "name": "sample.toml"
+        },
         "runtime_stats": {...
-        "spec_name": "sample.toml",
         "started": ...
         "statement": "select count(*) from countries",
         "version_info": {

--- a/cr8/run_spec.py
+++ b/cr8/run_spec.py
@@ -22,7 +22,9 @@ create table if not exists benchmarks (
         hash string
     ),
     statement string,
-    spec_name string,
+    meta object as (
+        name string
+    ),
     started timestamp,
     ended timestamp,
     concurrency int,
@@ -107,7 +109,7 @@ class Executor:
             aio.run_many(self.client.execute_many, inserts, concurrency=concurrency)
             cursor.execute('refresh table {target}'.format(target=data_file['target']))
 
-    def run_load_data(self, data_spec, spec_name=None):
+    def run_load_data(self, data_spec, meta=None):
         inserts = self._to_inserts(data_spec)
         statement = next(iter(inserts))[0]
         bulk_size = data_spec.get('bulk_size', 5000)
@@ -127,7 +129,7 @@ class Executor:
         self.process_result(Result(
             version_info=self.server_version_info,
             statement=statement,
-            spec_name=spec_name,
+            meta=meta,
             started=start,
             ended=end,
             stats=stats,
@@ -145,7 +147,7 @@ class Executor:
             server_version='.'.join((str(x) for x in self.server_version)))
         return msg
 
-    def run_queries(self, queries, spec_name=None):
+    def run_queries(self, queries, meta=None):
         for query in queries:
             stmt = query['statement']
             iterations = query.get('iterations', 1)
@@ -163,7 +165,7 @@ class Executor:
                        concurrency=concurrency)))
             with QueryRunner(
                 stmt,
-                spec_name,
+                meta,
                 repeats=iterations,
                 hosts=self.benchmark_hosts,
                 concurrency=concurrency,
@@ -227,9 +229,9 @@ def run_spec(spec, benchmark_hosts, result_hosts=None, output_fmt=None):
             print('# Running benchmark')
             if spec.load_data:
                 for data_spec in spec.load_data:
-                    executor.run_load_data(data_spec, spec.name)
+                    executor.run_load_data(data_spec, spec.meta)
             else:
-                executor.run_queries(spec.queries, spec.name)
+                executor.run_queries(spec.queries, spec.meta)
         finally:
             print('# Running tearDown')
             executor.exec_instructions(spec.teardown)

--- a/cr8/timeit.py
+++ b/cr8/timeit.py
@@ -18,6 +18,7 @@ class Result:
     def __init__(self,
                  version_info,
                  statement,
+                 spec_name,
                  started,
                  ended,
                  stats,
@@ -26,6 +27,7 @@ class Result:
                  output_fmt=None):
         self.version_info = version_info
         self.statement = statement
+        self.spec_name = spec_name
         # need ts in ms in crate
         self.started = int(started * 1000)
         self.ended = int(ended * 1000)
@@ -91,6 +93,7 @@ class Result:
 class QueryRunner:
     def __init__(self,
                  stmt,
+                 spec_name,
                  repeats,
                  hosts,
                  concurrency,
@@ -98,6 +101,7 @@ class QueryRunner:
                  bulk_args=None,
                  output_fmt=None):
         self.stmt = stmt
+        self.spec_name = spec_name
         self.repeats = repeats
         self.concurrency = concurrency
         self.hosts = hosts
@@ -127,6 +131,7 @@ class QueryRunner:
 
         return Result(
             statement=self.stmt,
+            spec_name=self.spec_name,
             version_info=version_info,
             started=started,
             ended=ended,
@@ -146,9 +151,11 @@ class QueryRunner:
 @argh.arg('-w', '--warmup', type=to_int)
 @argh.arg('-r', '--repeat', type=to_int)
 @argh.arg('-c', '--concurrency', type=to_int)
+@argh.arg('-l', '--label', type=str)
 @argh.arg('-of', '--output-fmt', choices=['full', 'short'], default='full')
 def timeit(hosts=None,
            stmt=None,
+           label=None,
            warmup=30,
            repeat=30,
            concurrency=1,
@@ -158,6 +165,7 @@ def timeit(hosts=None,
     num_lines = 0
     for line in lines_from_stdin(stmt):
         with QueryRunner(line,
+                         label,
                          repeat,
                          hosts=hosts,
                          concurrency=concurrency,

--- a/cr8/timeit.py
+++ b/cr8/timeit.py
@@ -18,7 +18,7 @@ class Result:
     def __init__(self,
                  version_info,
                  statement,
-                 spec_name,
+                 meta,
                  started,
                  ended,
                  stats,
@@ -27,7 +27,7 @@ class Result:
                  output_fmt=None):
         self.version_info = version_info
         self.statement = statement
-        self.spec_name = spec_name
+        self.meta = meta
         # need ts in ms in crate
         self.started = int(started * 1000)
         self.ended = int(ended * 1000)
@@ -93,7 +93,7 @@ class Result:
 class QueryRunner:
     def __init__(self,
                  stmt,
-                 spec_name,
+                 meta,
                  repeats,
                  hosts,
                  concurrency,
@@ -101,7 +101,7 @@ class QueryRunner:
                  bulk_args=None,
                  output_fmt=None):
         self.stmt = stmt
-        self.spec_name = spec_name
+        self.meta = meta
         self.repeats = repeats
         self.concurrency = concurrency
         self.hosts = hosts
@@ -131,7 +131,7 @@ class QueryRunner:
 
         return Result(
             statement=self.stmt,
-            spec_name=self.spec_name,
+            meta=self.meta,
             version_info=version_info,
             started=started,
             ended=ended,
@@ -151,11 +151,9 @@ class QueryRunner:
 @argh.arg('-w', '--warmup', type=to_int)
 @argh.arg('-r', '--repeat', type=to_int)
 @argh.arg('-c', '--concurrency', type=to_int)
-@argh.arg('-l', '--label', type=str)
 @argh.arg('-of', '--output-fmt', choices=['full', 'short'], default='full')
 def timeit(hosts=None,
            stmt=None,
-           label=None,
            warmup=30,
            repeat=30,
            concurrency=1,
@@ -165,7 +163,7 @@ def timeit(hosts=None,
     num_lines = 0
     for line in lines_from_stdin(stmt):
         with QueryRunner(line,
-                         label,
+                         None,
                          repeat,
                          hosts=hosts,
                          concurrency=concurrency,

--- a/tests/test_timeit.py
+++ b/tests/test_timeit.py
@@ -10,6 +10,7 @@ class ResultTest(TestCase):
         stats.measure(23.4)
         result = Result(
             version_info={},
+            spec_name=None,
             statement='select name from sys.cluster',
             started=10,
             ended=20,
@@ -32,6 +33,7 @@ class ResultTest(TestCase):
         stats.measure(15.9)
         result = Result(
             version_info={},
+            spec_name=None,
             statement='select name from sys.cluster',
             started=10,
             ended=20,

--- a/tests/test_timeit.py
+++ b/tests/test_timeit.py
@@ -10,7 +10,7 @@ class ResultTest(TestCase):
         stats.measure(23.4)
         result = Result(
             version_info={},
-            spec_name=None,
+            meta=None,
             statement='select name from sys.cluster',
             started=10,
             ended=20,
@@ -33,7 +33,7 @@ class ResultTest(TestCase):
         stats.measure(15.9)
         result = Result(
             version_info={},
-            spec_name=None,
+            meta=None,
             statement='select name from sys.cluster',
             started=10,
             ended=20,


### PR DESCRIPTION
Proposal: Adding a `meta` section to a spec and returning that in the
result output (also storing it in the result table of the benchmark
runs) allows you to easily identify and group results by a specific
spec.