### PR TITLE
print info messages and benchmark results to different outputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,6 @@
+ - Print info messages and benchmark results to different outputs, so results
+   can be piped into other programs such as ``jq`` or another python script.
+
 - Added ``meta`` object column to results table.
   It's now possible to add a name to the spec so the benchmark results can easily
   be identified by this spec label.

--- a/cr8/cli.py
+++ b/cr8/cli.py
@@ -75,17 +75,3 @@ def dicts_from_stdin():
     yield from dicts_from_lines(sys.stdin)
 
 dicts_from_stdin.__doc__ = dicts_from_lines.__doc__
-
-
-class Log:
-
-    @staticmethod
-    def stdout(*message):
-        '''Print to /dev/stdout'''
-        print(*message, file=sys.stdout)
-
-    @staticmethod
-    def stderr(*message):
-        '''Print to /dev/stderr'''
-        print(*message, file=sys.stderr)
-

--- a/cr8/cli.py
+++ b/cr8/cli.py
@@ -74,5 +74,18 @@ def dicts_from_stdin():
         raise SystemExit('Expected json input via stdin')
     yield from dicts_from_lines(sys.stdin)
 
-
 dicts_from_stdin.__doc__ = dicts_from_lines.__doc__
+
+
+class Log:
+
+    @staticmethod
+    def stdout(*message):
+        '''Print to /dev/stdout'''
+        print(*message, file=sys.stdout)
+
+    @staticmethod
+    def stderr(*message):
+        '''Print to /dev/stderr'''
+        print(*message, file=sys.stderr)
+

--- a/cr8/log.py
+++ b/cr8/log.py
@@ -1,0 +1,7 @@
+
+import sys
+import functools
+
+
+stdout = functools.partial(print, file=sys.stdout)
+stderr = functools.partial(print, file=sys.stderr)

--- a/cr8/run_crate.py
+++ b/cr8/run_crate.py
@@ -15,6 +15,7 @@ import io
 import tarfile
 from typing import Dict, Any
 from urllib.request import urlopen
+from .cli import Log
 
 
 log = logging.getLogger(__file__)
@@ -336,7 +337,7 @@ def run_crate(version, env=None, setting=None, crate_root=None):
         try:
             node.process.communicate()
         except KeyboardInterrupt:
-            print('Stopping Crate...')
+            Log.stderr('Stopping Crate...')
 
 
 if __name__ == "__main__":

--- a/cr8/run_crate.py
+++ b/cr8/run_crate.py
@@ -15,7 +15,6 @@ import io
 import tarfile
 from typing import Dict, Any
 from urllib.request import urlopen
-from .cli import Log
 
 
 log = logging.getLogger(__file__)
@@ -337,7 +336,7 @@ def run_crate(version, env=None, setting=None, crate_root=None):
         try:
             node.process.communicate()
         except KeyboardInterrupt:
-            Log.stderr('Stopping Crate...')
+            log.info('Stopping Crate...')
 
 
 if __name__ == "__main__":

--- a/cr8/run_spec.py
+++ b/cr8/run_spec.py
@@ -11,7 +11,7 @@ from .bench_spec import load_spec
 from .timeit import QueryRunner, Result
 from .misc import as_bulk_queries, as_statements, get_lines
 from .metrics import Stats
-from .cli import dicts_from_lines
+from .cli import dicts_from_lines, Log
 from . import clients
 
 
@@ -79,12 +79,12 @@ class Executor:
                         table_created.append(None)
                     stmt, args = to_insert('benchmarks', result.as_dict())
                     cursor.execute(stmt, args)
-                print(result)
-                print('')
+                Log.stdout(result)
+                Log.stderr('')
         else:
             def process_result(result):
-                print(result)
-                print('')
+                Log.stdout(result)
+                Log.stderr('')
         self.process_result = process_result
 
     def _to_inserts(self, data_spec):
@@ -154,9 +154,9 @@ class Executor:
             concurrency = query.get('concurrency', 1)
             min_version = _parse_version(query.get('min_version'))
             if min_version and min_version > self.server_version:
-                print(self._skip_message(min_version, stmt))
+                Log.stderr(self._skip_message(min_version, stmt))
                 continue
-            print(('\n## Running Query:\n'
+            Log.stderr(('\n## Running Query:\n'
                    '   Statement: {statement:.70}\n'
                    '   Concurrency: {concurrency}\n'
                    '   Iterations: {iterations}'.format(
@@ -224,16 +224,16 @@ def run_spec(spec, benchmark_hosts, result_hosts=None, output_fmt=None):
     ) as executor:
         spec = load_spec(spec)
         try:
-            print('# Running setUp')
+            Log.stderr('# Running setUp')
             executor.exec_instructions(spec.setup)
-            print('# Running benchmark')
+            Log.stderr('# Running benchmark')
             if spec.load_data:
                 for data_spec in spec.load_data:
                     executor.run_load_data(data_spec, spec.meta)
             else:
                 executor.run_queries(spec.queries, spec.meta)
         finally:
-            print('# Running tearDown')
+            Log.stderr('# Running tearDown')
             executor.exec_instructions(spec.teardown)
 
 

--- a/cr8/run_spec.py
+++ b/cr8/run_spec.py
@@ -11,8 +11,8 @@ from .bench_spec import load_spec
 from .timeit import QueryRunner, Result
 from .misc import as_bulk_queries, as_statements, get_lines
 from .metrics import Stats
-from .cli import dicts_from_lines, Log
-from . import clients
+from .cli import dicts_from_lines
+from . import clients, log
 
 
 BENCHMARK_TABLE = '''
@@ -79,12 +79,12 @@ class Executor:
                         table_created.append(None)
                     stmt, args = to_insert('benchmarks', result.as_dict())
                     cursor.execute(stmt, args)
-                Log.stdout(result)
-                Log.stderr('')
+                log.stdout(result)
+                log.stderr('')
         else:
             def process_result(result):
-                Log.stdout(result)
-                Log.stderr('')
+                log.stdout(result)
+                log.stderr('')
         self.process_result = process_result
 
     def _to_inserts(self, data_spec):
@@ -154,9 +154,9 @@ class Executor:
             concurrency = query.get('concurrency', 1)
             min_version = _parse_version(query.get('min_version'))
             if min_version and min_version > self.server_version:
-                Log.stderr(self._skip_message(min_version, stmt))
+                log.stderr(self._skip_message(min_version, stmt))
                 continue
-            Log.stderr(('\n## Running Query:\n'
+            log.stderr(('\n## Running Query:\n'
                    '   Statement: {statement:.70}\n'
                    '   Concurrency: {concurrency}\n'
                    '   Iterations: {iterations}'.format(
@@ -224,16 +224,16 @@ def run_spec(spec, benchmark_hosts, result_hosts=None, output_fmt=None):
     ) as executor:
         spec = load_spec(spec)
         try:
-            Log.stderr('# Running setUp')
+            log.stderr('# Running setUp')
             executor.exec_instructions(spec.setup)
-            Log.stderr('# Running benchmark')
+            log.stderr('# Running benchmark')
             if spec.load_data:
                 for data_spec in spec.load_data:
                     executor.run_load_data(data_spec, spec.meta)
             else:
                 executor.run_queries(spec.queries, spec.meta)
         finally:
-            Log.stderr('# Running tearDown')
+            log.stderr('# Running tearDown')
             executor.exec_instructions(spec.teardown)
 
 

--- a/cr8/run_track.py
+++ b/cr8/run_track.py
@@ -2,9 +2,9 @@ import argh
 import os
 import toml
 from glob import glob
-from .cli import Log
 from .run_spec import run_spec
 from .run_crate import CrateNode, get_crate
+from . import log
 
 
 class Executor:
@@ -22,7 +22,7 @@ class Executor:
     def _run_specs(self, specs, benchmark_host):
         specs = self._expand_paths(specs)
         for spec in specs:
-            Log.stderr('### Running spec file: ', os.path.basename(spec))
+            log.stderr('### Running spec file: ', os.path.basename(spec))
             run_spec(
                 spec,
                 benchmark_host,
@@ -33,9 +33,9 @@ class Executor:
         configurations = list(self._expand_paths(track['configurations']))
         versions = track['versions']
         for version in versions:
-            Log.stderr('# Version: ', version)
+            log.stderr('# Version: ', version)
             for c, configuration in enumerate(configurations):
-                Log.stderr('## Starting Crate {0}, configuration: {1}'.format(
+                log.stderr('## Starting Crate {0}, configuration: {1}'.format(
                     os.path.basename(version),
                     os.path.basename(configuration)
                 ))

--- a/cr8/run_track.py
+++ b/cr8/run_track.py
@@ -2,6 +2,7 @@ import argh
 import os
 import toml
 from glob import glob
+from .cli import Log
 from .run_spec import run_spec
 from .run_crate import CrateNode, get_crate
 
@@ -21,7 +22,7 @@ class Executor:
     def _run_specs(self, specs, benchmark_host):
         specs = self._expand_paths(specs)
         for spec in specs:
-            print('### Running spec file: ', os.path.basename(spec))
+            Log.stderr('### Running spec file: ', os.path.basename(spec))
             run_spec(
                 spec,
                 benchmark_host,
@@ -32,9 +33,9 @@ class Executor:
         configurations = list(self._expand_paths(track['configurations']))
         versions = track['versions']
         for version in versions:
-            print('# Version: ', version)
+            Log.stderr('# Version: ', version)
             for c, configuration in enumerate(configurations):
-                print('## Starting Crate {0}, configuration: {1}'.format(
+                Log.stderr('## Starting Crate {0}, configuration: {1}'.format(
                     os.path.basename(version),
                     os.path.basename(configuration)
                 ))

--- a/cr8/timeit.py
+++ b/cr8/timeit.py
@@ -8,10 +8,10 @@ import itertools
 from functools import partial
 from time import time
 
-from .cli import lines_from_stdin, to_int, Log
+from .cli import lines_from_stdin, to_int
 from .clients import client
 from .metrics import Stats
-from . import aio
+from . import aio, log
 
 
 class Result:
@@ -170,7 +170,7 @@ def timeit(hosts=None,
                          output_fmt=output_fmt) as runner:
             runner.warmup(warmup)
             result = runner.run()
-        Log.stdout(result)
+        log.stdout(result)
         num_lines += 1
     if num_lines == 0:
         raise SystemExit(

--- a/cr8/timeit.py
+++ b/cr8/timeit.py
@@ -8,7 +8,7 @@ import itertools
 from functools import partial
 from time import time
 
-from .cli import lines_from_stdin, to_int
+from .cli import lines_from_stdin, to_int, Log
 from .clients import client
 from .metrics import Stats
 from . import aio
@@ -170,7 +170,7 @@ def timeit(hosts=None,
                          output_fmt=output_fmt) as runner:
             runner.warmup(warmup)
             result = runner.run()
-        print(result)
+        Log.stdout(result)
         num_lines += 1
     if num_lines == 0:
         raise SystemExit(


### PR DESCRIPTION
This way you can pipe `stdout` to a different program:

```
cr8 run-spec specs/sample.toml localhost:4200 | jq .
```

PS: The integration test (README.rst) which uses `subprocess.call()` fails because `stderr` is printed prior to `stdout`. Could not figure out why this happens like that and not in the order the stuff is printed.
