### PR TITLE
support callable python object as statement

### DIFF
--- a/cr8/clients.py
+++ b/cr8/clients.py
@@ -42,6 +42,12 @@ async def _exec(session, url, data):
         return r['duration']
 
 
+def gen_stmt(stmt):
+    if callable(stmt):
+        return stmt()
+    return stmt
+
+
 class HttpClient:
     def __init__(self, hosts, conn_pool_limit=25):
         self.hosts = hosts
@@ -50,13 +56,13 @@ class HttpClient:
         self.session = aiohttp.ClientSession(connector=conn)
 
     async def execute(self, stmt, args=None):
-        payload = {'stmt': stmt}
+        payload = {'stmt': gen_stmt(stmt)}
         if args:
             payload['args'] = args
         return await _exec(self.session, next(self.urls), json.dumps(payload))
 
     async def execute_many(self, stmt, bulk_args):
-        data = json.dumps(dict(stmt=stmt, bulk_args=bulk_args))
+        data = json.dumps(dict(stmt=gen_stmt(stmt), bulk_args=bulk_args))
         return await _exec(self.session, next(self.urls), data)
 
     async def get_server_version(self):

--- a/cr8/run_spec.py
+++ b/cr8/run_spec.py
@@ -156,7 +156,7 @@ class Executor:
                    '   Statement: {statement:.70}\n'
                    '   Concurrency: {concurrency}\n'
                    '   Iterations: {iterations}'.format(
-                       statement=stmt,
+                       statement=str(stmt),
                        iterations=iterations,
                        concurrency=concurrency)))
             with QueryRunner(

--- a/cr8/timeit.py
+++ b/cr8/timeit.py
@@ -25,7 +25,7 @@ class Result:
                  bulk_size=None,
                  output_fmt=None):
         self.version_info = version_info
-        self.statement = statement
+        self.statement = str(statement)
         # need ts in ms in crate
         self.started = int(started * 1000)
         self.ended = int(ended * 1000)


### PR DESCRIPTION
Example for a benchmark that adds 100 columns using a statement
generating callable:

```py
class ColumnGenerator:

    def __init__(self, prefix):
        self.prefix = prefix
        self.stmt = 'alter table t_add_column add column "{}_{}" string'
        self.count = 0

    def __call__(self):
        self.count += 1
        return self.stmt.format(self.prefix, self.count)

    def __str__(self):
        return self.stmt

spec = Spec(
    setup=Instructions(
        statements=[...]
    ),
    teardown=Instructions(
        statements=[...]
    ),
    queries=[
        {
            'statement': ColumnGenerator('str_col'),
            'iterations': 100,
        },
    ]
)
```