### PR TITLE
Change run-crate to lookup correct version for `latest-stable`

### DIFF
--- a/cr8/run_crate.py
+++ b/cr8/run_crate.py
@@ -281,8 +281,8 @@ def _get_latest_nightly_uri():
 
 
 _version_lookups = {
-    'latest': _from_versions_json('crate-java'),
-    'latest-stable': _from_versions_json('crate-java'),
+    'latest': _from_versions_json('crate'),
+    'latest-stable': _from_versions_json('crate'),
     'latest-testing': _from_versions_json('crate_testing'),
     'latest-nightly': _get_latest_nightly_uri
 }


### PR DESCRIPTION
It used the java-client version instead of the server version