### PR TITLE
Create aiohttp ClientSession lazy in an async func

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'argh',
         'tqdm',
         'fake-factory==0.5.7',
-        'aiohttp>=1.1,<1.2',
+        'aiohttp>=1.1,<2',
         'toml'
     ],
     extras_require={


### PR DESCRIPTION
In order to avoid warnings that are printed since aiohttp 1.2