### PR TITLE
pass locale LANG to subprocess

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@
 ``run-crate``
 -------------
 
+- Pass ``LANG`` environment variable to ``crate`` subprocess.
+  This fixes encoding issues when passing unicode characters as CrateDB setting
+  values.
+
 - It's now possible to launch SSL enabled nodes. Before ``run-crate`` would run
   into a timeout.
 

--- a/cr8/run_crate.py
+++ b/cr8/run_crate.py
@@ -189,7 +189,13 @@ class CrateNode(contextlib.ExitStack):
         self.crate_dir = crate_dir
         version = _extract_version(crate_dir)
         self.env = env or {}
-        self.env.setdefault('JAVA_HOME', os.environ.get('JAVA_HOME', ''))
+        self.env.setdefault('JAVA_HOME',
+                            os.environ.get('JAVA_HOME', ''))
+        self.env.setdefault('LANG',
+                            os.environ.get('LANG', os.environ.get('LC_ALL')))
+        if not self.env['LANG']:
+            raise SystemError('Your locale are not configured correctly. '
+                              'Please set LANG or alternatively LC_ALL.')
         self.monitor = OutputMonitor()
         self.process = None  # type: subprocess.Popen
         self.http_url = None  # type: str


### PR DESCRIPTION
this fixes encoding issues when using unicode charactes in CrateDB
setting values, e.g.

```
cr8 run-crate 2.1.7 -s node.name="لمهندس مؤ"
```