### PR TITLE
catch ConnectionRefusedError in _is_up function

### DIFF
--- a/cr8/run_crate.py
+++ b/cr8/run_crate.py
@@ -122,7 +122,7 @@ def _is_up(host: str, port: int):
         conn = _create_connection(host, port)
         conn.close()
         return True
-    except socket.gaierror:
+    except (socket.gaierror, ConnectionRefusedError):
         return False
 
 


### PR DESCRIPTION
```
======================================================================
ERROR: test_blob_index (restart.test_blob.BlobTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/lib/jenkins/jobs/CrateDB/jobs/qa/jobs/crate-qa/workspace/tests/restart/test_blob.py", line 25, in test_blob_index
    node.start()
  File "/var/lib/jenkins/jobs/CrateDB/jobs/qa/jobs/crate-qa/workspace/env/lib64/python3.6/site-packages/cr8/run_crate.py", line 279, in start
    timeout=30
  File "/var/lib/jenkins/jobs/CrateDB/jobs/qa/jobs/crate-qa/workspace/env/lib64/python3.6/site-packages/cr8/run_crate.py", line 115, in wait_until
    r = predicate()
  File "/var/lib/jenkins/jobs/CrateDB/jobs/qa/jobs/crate-qa/workspace/env/lib64/python3.6/site-packages/cr8/run_crate.py", line 278, in <lambda>
    lambda: _ensure_running(proc) and _is_up(host, port),
  File "/var/lib/jenkins/jobs/CrateDB/jobs/qa/jobs/crate-qa/workspace/env/lib64/python3.6/site-packages/cr8/run_crate.py", line 122, in _is_up
    conn = _create_connection(host, port)
  File "/var/lib/jenkins/jobs/CrateDB/jobs/qa/jobs/crate-qa/workspace/env/lib64/python3.6/site-packages/cr8/run_crate.py", line 132, in _create_connection
    return socket.create_connection((host, port))
  File "/usr/lib64/python3.6/socket.py", line 722, in create_connection
    raise err
  File "/usr/lib64/python3.6/socket.py", line 713, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused
```