### PR TITLE
Insert empty objects for object columns

### DIFF
--- a/cr8/insert_fake_data.py
+++ b/cr8/insert_fake_data.py
@@ -33,6 +33,7 @@ where
     is_generated = false
     and {schema_column_name} = ?
     and table_name = ?
+    and column_name not like '%]'
 order by ordinal_position asc
 """
 
@@ -82,6 +83,7 @@ class DataFaker:
         'boolean': operator.attrgetter('boolean'),
         'geo_point': operator.attrgetter('geo_point'),
         'geo_shape': operator.attrgetter('geo_shape'),
+        'object': lambda f: dict
     }
 
     _custom = {

--- a/tests/test_insert_fake_data.py
+++ b/tests/test_insert_fake_data.py
@@ -96,6 +96,10 @@ class TestDataFaker(TestCase):
             self.f.provider_for_column('x', 'y')
         self.assertEqual(str(cm.exception), msg)
 
+    def test_provider_for_object_column_creates_empty_dicts(self):
+        provider = self.f.provider_for_column('obj', 'object')
+        self.assertEqual(provider(), dict())
+
 
 def load_tests(loader, tests, ignore):
     tests.addTests(DocTestSuite(insert_fake_data))


### PR DESCRIPTION
Ideally we'd resolve the child column types and create proper random
data. But this is a quick solution to at least avoid failures.