### PR TITLE
Do not trim statements being run with run-spec

### DIFF
--- a/cr8/run_spec.py
+++ b/cr8/run_spec.py
@@ -163,7 +163,8 @@ class Executor:
             mode_desc = 'Duration' if duration else 'Iterations'
             self.log.info(
                 (f'\n## Running Query:\n'
-                 f'   Statement: {stmt:.70}\n'
+                 f'   Statement:\n'
+                 f'     {stmt}\n'
                  f'   Concurrency: {concurrency}\n'
                  f'   {mode_desc}: {duration or iterations}')
             )


### PR DESCRIPTION
So that the query can be copy pasted.