### PR TITLE
Verify checksum of local tarballs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -308,7 +308,6 @@ will be executed::
     >>> cr8 run-track tracks/sample.toml
     # Version:  latest-testing
     ## Starting Crate latest-testing, configuration: default.toml
-    ...
     ### Running spec file:  sample.toml
     # Running setUp
     # Running benchmark


### PR DESCRIPTION
Adds checksumming for local tarballs in the cache to avoid using stale
cached versions.

When testing locally built tarballs the contents may change but the name
might stay the same if no commits are made. In such a case the changes
weren't picked up because the cache was used.