### PR TITLE
Wrap BrokenPipeError

### DIFF
--- a/cr8/insert_json.py
+++ b/cr8/insert_json.py
@@ -7,7 +7,7 @@ from functools import partial
 
 from .cli import dicts_from_stdin, to_int
 from .misc import as_bulk_queries
-from . import aio, clients
+from cr8 import aio, clients
 from .metrics import Stats
 from .log import format_stats
 
@@ -50,7 +50,7 @@ def print_only(table):
           to execute the insert statement', type=str)
 @argh.arg('-c', '--concurrency', type=to_int)
 @argh.arg('-of', '--output-fmt', choices=['json', 'text'], default='text')
-@argh.wrap_errors([KeyboardInterrupt] + clients.client_errors)
+@argh.wrap_errors([KeyboardInterrupt, BrokenPipeError] + clients.client_errors)
 def insert_json(table=None,
                 bulk_size=1000,
                 concurrency=25,

--- a/cr8/run_spec.py
+++ b/cr8/run_spec.py
@@ -236,7 +236,7 @@ def do_run_spec(spec,
 @argh.arg('--logfile-result', help='Redirect benchmark results to a file')
 @argh.arg('--sample-mode', choices=('all', 'reservoir'),
           help='Method used for sampling', default='reservoir')
-@argh.wrap_errors([KeyboardInterrupt] + clients.client_errors)
+@argh.wrap_errors([KeyboardInterrupt, BrokenPipeError] + clients.client_errors)
 def run_spec(spec,
              benchmark_hosts,
              result_hosts=None,

--- a/cr8/run_track.py
+++ b/cr8/run_track.py
@@ -100,7 +100,7 @@ class Executor:
 @argh.arg('--logfile-result', help='Redirect benchmark results to a file')
 @argh.arg('--sample-mode', choices=('all', 'reservoir'),
           help='Method used for sampling', default='reservoir')
-@argh.wrap_errors([KeyboardInterrupt] + client_errors)
+@argh.wrap_errors([KeyboardInterrupt, BrokenPipeError] + client_errors)
 def run_track(track,
               result_hosts=None,
               crate_root=None,

--- a/cr8/timeit.py
+++ b/cr8/timeit.py
@@ -3,12 +3,12 @@
 
 import argh
 
-from . import aio
-from .cli import lines_from_stdin, to_int
-from .misc import as_statements
-from .log import Logger
-from .clients import client_errors
-from .engine import Runner, Result, eval_fail_if
+from cr8 import aio
+from cr8.cli import lines_from_stdin, to_int
+from cr8.misc import as_statements
+from cr8.log import Logger
+from cr8.clients import client_errors
+from cr8.engine import Runner, Result, eval_fail_if
 
 
 @argh.arg('--hosts', help='crate hosts', type=str)
@@ -24,7 +24,7 @@ from .engine import Runner, Result, eval_fail_if
           failure if it evaluates to true')
 @argh.arg('--sample-mode', choices=('all', 'reservoir'),
           help='Method used for sampling', default='reservoir')
-@argh.wrap_errors([KeyboardInterrupt] + client_errors)
+@argh.wrap_errors([KeyboardInterrupt, BrokenPipeError] + client_errors)
 def timeit(hosts=None,
            stmt=None,
            warmup=30,


### PR DESCRIPTION
BrokenPipeError shouldn't result in a scary error. That happens if the
result of cr8 is piped to another process that exists with an error
code.