### PR TITLE
Increase run-crate start-up timeout to 60 seconds

### DIFF
--- a/cr8/run_crate.py
+++ b/cr8/run_crate.py
@@ -280,7 +280,7 @@ class CrateNode(contextlib.ExitStack):
         try:
             wait_until(
                 lambda: show_spinner() and _ensure_running(proc) and self.http_host,
-                timeout=30
+                timeout=60
             )
             host = self.addresses.http.host
             port = self.addresses.http.port

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,6 +12,7 @@ node = CrateNode(
     settings={
         'cluster.name': 'cr8-tests',
         'http.port': '44200-44250',
+        'bootstrap.system_call_filter': False
     })
 
 


### PR DESCRIPTION
Should be enough to start up CrateDB on a raspberry