### PR TITLE
Change timestamp default faker to -2y - now

### DIFF
--- a/cr8/clients.py
+++ b/cr8/clients.py
@@ -224,7 +224,7 @@ class AsyncpgClient:
         pool = await self._get_pool()
         async with pool.acquire() as conn:
             if args:
-                rows = await conn.fetch(stmt, args)
+                rows = await conn.fetch(stmt, *args)
             else:
                 rows = await conn.fetch(stmt)
             return {

--- a/cr8/insert_fake_data.py
+++ b/cr8/insert_fake_data.py
@@ -51,16 +51,6 @@ def generate_row(fakers):
     return [x() for x in fakers]
 
 
-def x1000(func):
-    return func() * 1000
-
-
-def timestamp(fake):
-    # return lamda: fake.unix_time() * 1000 workaround:
-    # can't use lambda or nested functions because of multiprocessing pickling
-    return partial(x1000, fake.unix_time)
-
-
 def array_provider(len_provider, value_provider, dimensions):
     if dimensions == 0:
         return value_provider()
@@ -94,7 +84,8 @@ class DataFaker:
         'float': operator.attrgetter('pyfloat'),
         'double': operator.attrgetter('pydecimal'),
         'ip': operator.attrgetter('ipv4'),
-        'timestamp': timestamp,
+        'timestamp': lambda f: partial(
+            f.date_time_between, start_date='-2y', end_date='now'),
         'string': operator.attrgetter('word'),
         'boolean': operator.attrgetter('boolean'),
         'geo_point': operator.attrgetter('geo_point'),

--- a/tests/test_insert_fake_data.py
+++ b/tests/test_insert_fake_data.py
@@ -3,6 +3,7 @@ from cr8 import insert_fake_data
 from unittest import TestCase, main
 from doctest import DocTestSuite
 from decimal import Decimal
+import datetime
 
 
 class TestDataFaker(TestCase):
@@ -43,11 +44,15 @@ class TestDataFaker(TestCase):
 
     def test_timestamp_column_default(self):
         provider = self.f.provider_for_column('timestamp', 'timestamp')
-        self.assertEqual(provider(), 1373158606000)
+        dt = provider()
+        diff = datetime.datetime(2017, 11, 18, 19, 0, 0) - dt
+        self.assertLessEqual(diff, datetime.timedelta(seconds=1))
 
     def test_timestamp_type_default(self):
         provider = self.f.provider_for_column('some_ts_column', 'timestamp')
-        self.assertEqual(provider(), 1373158606000)
+        dt = provider()
+        diff = datetime.datetime(2017, 11, 18, 19, 0, 0) - dt
+        self.assertLessEqual(diff, datetime.timedelta(seconds=1))
 
     def test_provider_from_mapping(self):
         mapping = {'x': ['random_int', [10, 20]]}


### PR DESCRIPTION
And use `datetime` instead of a unix timestamp to make it work with the
postgres client as well.