### PR TITLE
Do not pretty print JSON output

### DIFF
--- a/cr8/log.py
+++ b/cr8/log.py
@@ -5,7 +5,7 @@ from functools import partial
 
 
 _wopen = partial(open, mode='w', encoding='utf-8')
-to_jsonstr = partial(json.dumps, sort_keys=True, indent=4)
+to_jsonstr = json.dumps
 
 
 def _format_short(stats):


### PR DESCRIPTION
Makes it easier to process the generated JSON by tools that work with
JSONL (1 JSON object per line)

The JSON format is usually used for further processing, not as "human
readable output".
For pretty printing users should use `jq` or `python -mjson.tool`.