### PR TITLE
Handle status 401 from http client

### DIFF
--- a/cr8/clients.py
+++ b/cr8/clients.py
@@ -84,6 +84,9 @@ async def _exec(session, url, data):
                             data=data,
                             headers=HTTP_DEFAULT_HDRS,
                             timeout=None) as resp:
+        if resp.status == 401:
+            t = await resp.text()
+            raise SqlException(t)
         r = await resp.json()
         if 'error' in r:
             raise SqlException(


### PR DESCRIPTION
If the a client is not authenticated the request fails with

```
ContentTypeError: 0, message='Attempt to decode JSON with unexpected mimetype: '
```

Which is not very helpful. This fix prints the error message returned from the backend in case of 401.