### PR TITLE
Make information_schema.columns query compat for 4.0

### DIFF
--- a/cr8/insert_fake_data.py
+++ b/cr8/insert_fake_data.py
@@ -30,7 +30,7 @@ select
 from
     information_schema.columns
 where
-    is_generated = false
+    cast(is_generated as string) in ('f', 'NEVER')
     and {schema_column_name} = ?
     and table_name = ?
     and column_name not like '%]'


### PR DESCRIPTION
`is_generated` was changed to a string to be compatible with the SQL
standard.