### PR TITLE
Various fixes for `reindex`

### DIFF
--- a/cr8/reindex.py
+++ b/cr8/reindex.py
@@ -97,6 +97,9 @@ async def _async_reindex(client):
         raise ValueError("reindex only works on a CrateDB cluster running 3.3.0 or later")
     tables = await _fetch_tables_to_upgrade(client, version)
     for schema, table in tables:
+        if schema == 'blob':
+            print(f'Skipping unsupported BLOB table "{schema}"."{table}"')
+            continue
         create_table = await _show_create_table(client, f'"{schema}"."{table}"')
         column_names = await _fetch_column_names(client, schema, table)
         await _reindex_table(client, schema, table, create_table, column_names)

--- a/cr8/reindex.py
+++ b/cr8/reindex.py
@@ -97,7 +97,7 @@ async def _async_reindex(client):
         raise ValueError("reindex only works on a CrateDB cluster running 3.3.0 or later")
     tables = await _fetch_tables_to_upgrade(client, version)
     for schema, table in tables:
-        create_table = await _show_create_table(client, f'{schema}.{table}')
+        create_table = await _show_create_table(client, f'"{schema}"."{table}"')
         column_names = await _fetch_column_names(client, schema, table)
         await _reindex_table(client, schema, table, create_table, column_names)
 


### PR DESCRIPTION
- Fix error when table name contains `-` by adding quotes in query
```
cr8.clients.SqlException: SQLActionException[SQLParseException: line 1:26: mismatched input '.' expecting <EOF>] occurred using: {"stmt": "SHOW CREATE TABLE testing.my-table"}
```
- Fix error for BLOB tables by skipping them (can BLOB tables even be reindexed ?)
```
cr8.clients.SqlException: SQLActionException[OperationOnInaccessibleRelationException: The relation "blob.document" doesn't support or allow SHOW CREATE operations.] occurred using: {"stmt": "SHOW CREATE TABLE \"blob\".\"document\""}
```