### PR TITLE
Add `asyncpg` as default dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pycodestyle asyncpg
+          pip install pycodestyle
           pip install .
 
       - name: Test

--- a/README.rst
+++ b/README.rst
@@ -381,11 +381,14 @@ from 2.x would be re-created::
 Protocols
 =========
 
-``cr8`` supports using ``HTTP`` or the ``postgres`` protocol if the extra
-dependency ``asyncpg`` is installed.
+``cr8`` supports using ``HTTP`` or the ``postgres`` protocol.
 
 Note that using the postgres protocol will cause ``cr8`` to measure the
-round-trip time instead of the service time. So measurements will be different::
+round-trip time instead of the service time. So measurements will be different.
+
+To use the ``postgres`` protocol, the ``asyncpg`` scheme must be used inside hosts URIs:
+
+::
 
 
     >>> echo "select 1" | cr8 timeit --hosts asyncpg://localhost:5432

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,11 @@ setup(
         'tqdm',
         'Faker>=4.0,<5.0',
         'aiohttp>=3.3,<4',
-        'toml'
+        'toml',
+        'asyncpg'
     ],
     extras_require={
-        'extra': ['uvloop', 'pysimdjson'],
-        'asyncpg': ['asyncpg']
+        'extra': ['uvloop', 'pysimdjson']
     },
     python_requires='>=3.6',
     classifiers=[


### PR DESCRIPTION
The recently added command `insert-from-sql` requires `asyncpg` and thus it is not optional anymore.

Follow up of https://github.com/mfussenegger/cr8/commit/c8209e171d7c26a090aa2793ce4dee23886c52e5.