### PR TITLE
Increase timeout for CrateNode.stop

### DIFF
--- a/cr8/run_crate.py
+++ b/cr8/run_crate.py
@@ -379,7 +379,7 @@ class CrateNode(contextlib.ExitStack):
     def stop(self):
         if self.process:
             self.process.terminate()
-            self.process.communicate(timeout=10)
+            self.process.communicate(timeout=120)
         self.addresses = DotDict({})
         self.http_host = None
         self.http_url = None


### PR DESCRIPTION
A clean shutdown procedure for CrateDB can take quite a while.
