### PR TITLE
Don't inherit stdin when building crate from source/branch

### DIFF
--- a/cr8/run_crate.py
+++ b/cr8/run_crate.py
@@ -577,7 +577,7 @@ def _is_project_repo(src_repo):
 
 def _build_tarball(src_repo) -> Path:
     """ Build a tarball from src and return the path to it """
-    run = partial(subprocess.run, cwd=src_repo, check=True)
+    run = partial(subprocess.run, cwd=src_repo, check=True, stdin=subprocess.DEVNULL)
     run(['git', 'clean', '-xdff'])
     src_repo = Path(src_repo)
     if os.path.exists(src_repo / 'es' / 'upstream'):
@@ -597,10 +597,15 @@ def _extract_tarball(tarball):
 def _build_from_release_branch(branch, crate_root):
     crates = Path(crate_root)
     src_repo = crates / 'sources_tmp'
-    run_in_repo = partial(subprocess.run, cwd=src_repo, check=True)
+    run_in_repo = partial(
+        subprocess.run,
+        cwd=src_repo,
+        check=True,
+        stdin=subprocess.DEVNULL
+    )
     if not src_repo.exists() or not (src_repo / '.git').exists():
         clone = ['git', 'clone', REPO_URL, 'sources_tmp']
-        subprocess.run(clone, cwd=crate_root, check=True)
+        subprocess.run(clone, cwd=crate_root, check=True, stdin=subprocess.DEVNULL)
     else:
         run_in_repo(['git', 'fetch'])
     run_in_repo(['git', 'checkout', branch])


### PR DESCRIPTION
To support something like:

    git bisect run cr8 run-crate "$(pwd)" -e CRATE_HEAP_SIZE=4G -- @crash < $HOME/repro.sql

If the subprocess inherits the parent's stdin file descriptor, the build
process consumes the data from stdin, leaving nothing for the later
process.
