### PR TITLE
Fix maven command in run-crate 

### DIFF
--- a/cr8/run_crate.py
+++ b/cr8/run_crate.py
@@ -587,7 +587,7 @@ def _build_tarball(src_repo) -> Path:
         run(['git', 'submodule', 'update', '--init', '--', 'es/upstream'])
     if (path / "mvnw").exists():
         run([
-            "mvnw",
+            "./mvnw",
             "-T", "1C",
             "clean",
             "package",


### PR DESCRIPTION
This fixes the following problem on my local machine:
```
  File "/usr/local/Cellar/python@3.11/3.11.5/Frameworks/Python.framework/Versions/3.11/lib/python3.11/subprocess.py", line 1950, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'mvnw'
```

Is this a setup-failure on my side ?
