### PR TITLE
Add support for camel case column names in target for insert-from-sql

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,7 +190,7 @@ Copies data from one CrateDB cluster or PostgreSQL server to another.
     ...   --query "SELECT name FROM x.demo" \
     ...   --hosts localhost:4200 \
     ...   --table y.demo \
-    INSERT INTO y.demo (name) VALUES ($1)
+    INSERT INTO y.demo ("name") VALUES ($1)
     Runtime (in ms):
     ...
 

--- a/cr8/insert_from_sql.py
+++ b/cr8/insert_from_sql.py
@@ -12,7 +12,7 @@ from cr8.log import format_stats
 
 
 def mk_insert(table, attributes):
-    columns = ', '.join((x.name for x in attributes))
+    columns = ', '.join(('"' + x.name + '"' for x in attributes))
     params = ', '.join((f'${i + 1}' for i in range(len(attributes))))
     return f'INSERT INTO {table} ({columns}) VALUES ({params})'
 


### PR DESCRIPTION
This allows insert-from-sql to be used in situations like the below:

```sql
CREATE TABLE tbl1("COL1" int);
INSERT INTO tbl1 SELECT 1;
CREATE TABLE tbl2("COL1" int);
``` 

```bash
cr8 insert-from-sql \
   --src-uri "postgresql://crate@localhost:5432/doc" \
   --query "SELECT * FROM tbl1" \
   --hosts localhost:4200 \
   --table doc.tbl2
```