### PR TITLE
Maintenance: Add support for Python 3.12 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@master

--- a/cr8/__init__.py
+++ b/cr8/__init__.py
@@ -1,3 +1,9 @@
-import pkg_resources
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ModuleNotFoundError:  # pragma:nocover
+    from importlib_metadata import PackageNotFoundError, version
 
-__version__ = pkg_resources.require('cr8')[0].version
+try:
+    __version__ = version("cr8")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
         'Faker>=4.0,<5.0',
         'aiohttp>=3.3,<4',
         'toml;python_version<"3.11"',
-        'asyncpg'
+        'asyncpg',
+        'importlib-metadata;python_version<"3.8"',
     ],
     extras_require={
         'extra': ['uvloop', 'pysimdjson']
@@ -44,6 +45,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     use_scm_version=True,
     setup_requires=['setuptools_scm']


### PR DESCRIPTION
## About
This patch adds support for Python 3.12, in order to support QA/maintenance on CrateDB ecosystem matters.
- https://github.com/crate/cratedb-examples/pull/283

## Details
The `pkg_resources` module became deprecated. `importlib.metadata` is
the right choice now to inquire package versions.

However, it is only there starting with Python 3.8. For Python 3.7,
there is the `importlib-metadata` backport package on PyPI.

## Validation
The patch has been validated on behalf of the downstream repository.
https://github.com/daq-tools/cr8/actions/runs/7855702978/job/21437691771
