### PR TITLE
CI: Modernize GHA configuration recipe

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,10 +53,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       - name: Build package
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: '11'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -50,7 +50,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: Set up python 3.7
         uses: actions/setup-python@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: 3.7
 


### PR DESCRIPTION
## About
This patch modernizes the CI/GHA workflow configuration, i.e. bumps a few version numbers of GitHub Actions.

## Validation
An [earlier CI run](https://github.com/daq-tools/cr8/actions/runs/7855702978) displayed a few deprecation warnings, now it is [free of them](https://github.com/daq-tools/cr8/actions/runs/7855784694).
