### PR TITLE
Add support for Python 3.12/missing setuptools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@master

--- a/cr8/__init__.py
+++ b/cr8/__init__.py
@@ -1,3 +1,11 @@
-import pkg_resources
-
-__version__ = pkg_resources.require('cr8')[0].version
+try:
+    from importlib.metadata import version, PackageNotFoundError
+    __version__ = version("cr8")
+except ImportError:
+    try:
+        import pkg_resources
+        __version__ = pkg_resources.require('cr8')[0].version
+    except ImportError:
+        __version__ = "unknown"
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     use_scm_version=True,
     setup_requires=['setuptools_scm']


### PR DESCRIPTION
With python 3.12 `pkg_resources` is no longer available by default with
`python -m venv` because setuptools is no longer included by default.

Same is the case if using an alternative pip implementation like `uv pip`

Alternative to https://github.com/mfussenegger/cr8/pull/371
