### PR TITLE
Revert "Use `data` filter for tarball extraction if available"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,16 @@
+2024-03-25 0.26.1
+=================
+
+- Fixed a regression that could lead to errors using ``cr8 run-crate`` when it
+  tries to extract the CrateDB tarball.
+
 2024-03-20 0.26.0
 =================
 
 - Added support for python 3.12
 
-- Fixed a permission denied error that could occur using `cr8 run-crate` with a
-  branch version specification.
+- Fixed a permission denied error that could occur using ``cr8 run-crate`` with
+  a branch version specification.
 
 2023-10-24 0.25.0
 =================

--- a/cr8/run_crate.py
+++ b/cr8/run_crate.py
@@ -483,7 +483,6 @@ def _download_and_extract(uri, crate_root):
     log.info('Downloading %s and extracting to %s', uri, crate_root)
     with _openuri(uri) as tmpfile:
         with tarfile.open(fileobj=tmpfile) as t:
-            t.extraction_filter = getattr(tarfile, 'data_filter', (lambda member, path: member))
             t.extractall(crate_root)
         tmpfile.seek(0)
         checksum = sha1(tmpfile.read()).hexdigest()
@@ -613,7 +612,6 @@ def _extract_tarball(tarball):
         target = tarball.parent / folder_name
         if target.exists():
             shutil.rmtree(target)
-        t.extraction_filter = getattr(tarfile, 'data_filter', (lambda member, path: member))
         t.extractall(tarball.parent)
     return str(tarball.parent / folder_name)
 


### PR DESCRIPTION
This reverts commit a24a5aceeccb2765c0ed30dd4bdb301a4e215502.
